### PR TITLE
Adding a new ranker factory that manages what ranker to return

### DIFF
--- a/data/processors/ItemProcessor.py
+++ b/data/processors/ItemProcessor.py
@@ -9,5 +9,5 @@ class ItemProcessor:
     At a later date, we will define the contents of the dictionary via some strong typing.
     For now, we'll assume the keys are known to the outside callers.
     """
-    def process(self, source_image_path:str) -> {} :
+    def process(self, source_image_path:str) -> {}:
         pass

--- a/data/rankers/ImageRanker.py
+++ b/data/rankers/ImageRanker.py
@@ -1,0 +1,73 @@
+"""
+This class will contain methods and interfaces that will operate on a processed corpus and retrieve a list of images
+"""
+from yearbook.Corpus import Corpus
+from abc import ABC, abstractmethod
+
+
+class ImageRanker(ABC):
+
+    @abstractmethod
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+
+    @abstractmethod
+    def rank(self, school: str, grade: str, classroom: str, child: str, event_name: str) -> []:
+        pass
+
+    @abstractmethod
+    def whoamI(self):
+        pass
+
+
+class SchoolRanker(ImageRanker):
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+        self.school_name = "Unknown"
+
+    def __init__(self, corpus: Corpus, school_name: str):
+        super(SchoolRanker, self).__init__(corpus)
+        self.school_name = school_name
+
+    def rank(self, school: str, grade: str, classroom: str, child: str, event_name: str) -> []:
+        # Return a list of images that are applicable to the school level
+        return self.corpus.get_images_for_event(event_name)
+
+    def whoamI(self):
+        print("SchoolRanker, %s" % self.school_name)
+
+
+class GradeRanker(ImageRanker):
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+
+    def rank(self, school: str, grade: str, classroom: str, child: str, event_name: str) -> []:
+        # Return a list of images that are applicable to the grade level
+        return self.corpus.get_images_for_event(event_name)
+
+    def whoamI(self):
+        print("GradeRanker")
+
+
+class ClassroomRanker(ImageRanker):
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+
+    def rank(self, school: str, grade: str, classroom: str, child: str, event_name: str) -> []:
+        # Return a list of images that are applicable to the classroom level
+        return self.corpus.get_images_for_event(event_name)
+
+    def whoamI(self):
+        print("ClassRoomRanker")
+
+
+class ChildRanker(ImageRanker):
+    def __init__(self, corpus: Corpus):
+        self.corpus = corpus
+
+    def rank(self, school: str, grade: str, classroom: str, child: str, event_name: str) -> []:
+        # Return a list of images that are applicable to the child
+        return self.corpus.get_filenames_child_images_for_event(child, event_name)
+
+    def whoamI(self):
+        print("ChildRanker")

--- a/data/rankers/RankerFactory.py
+++ b/data/rankers/RankerFactory.py
@@ -1,0 +1,22 @@
+from data.rankers.ImageRanker import SchoolRanker, GradeRanker, ClassroomRanker, ChildRanker
+from yearbook.Corpus import Corpus
+
+"""
+For now we're going to return new objects
+Eventually the rankers will get smarter and will have some caching
+"""
+
+rankerFactory = {}
+
+
+def create_ranker(corpus: Corpus, school: str, grade: str, classroom: str, child: str):
+    if grade is None:
+        if school not in rankerFactory:
+            rankerFactory[school] = SchoolRanker(corpus, school)
+        return rankerFactory[school]
+    elif classroom is None:
+        return GradeRanker(corpus)
+    elif child is None:
+        return ClassroomRanker(corpus)
+    else:
+        return ChildRanker(corpus)

--- a/data/readers/default.py
+++ b/data/readers/default.py
@@ -46,4 +46,5 @@ def corpus_processor(corpus_file) -> {}:
         sorted_images = sorted(imgs, key=lambda x: x[1], reverse=True)
         face_to_image_map[face] = sorted_images
 
-    return Corpus(image_map=all_images_map, child_to_images=face_to_image_map, events_to_images=event_to_image_map)
+    import os
+    return Corpus(image_map=all_images_map, child_to_images=face_to_image_map, events_to_images=event_to_image_map,corpus_dir=os.path.dirname(corpus_file))

--- a/data/readers/tests/test_default_reader.py
+++ b/data/readers/tests/test_default_reader.py
@@ -30,6 +30,7 @@ class TestDefaultReader(unittest.TestCase):
         assert self.corpus.get_child_images_for_event_with_scores('Elise', 'Front_Cover') is not None
         assert len(self.corpus.get_child_images_for_event_with_scores('Elise', 'Front_Cover')) == 3
         print(self.corpus.get_child_images_for_event_with_scores('Elise', 'Front_Cover'))
+        print(self.corpus.get_child_images_for_event_with_scores('Elisah', 'Front_Cover'))
 
     def test_face_bounding_box(self):
         print("Running Test with scores")
@@ -48,11 +49,14 @@ class TestDefaultReader(unittest.TestCase):
 
     def test_get_filenames_child_images_for_event(self):
         corpus = corpus_processor('./processedCorpus_2.test')
-        christmas_imgs_per_child1 = corpus.get_filenames_child_images_for_event("Rilee", "Christmas", "test_dir")
-        christmas_imgs_per_child2 = corpus.get_filenames_child_images_for_event("child3", "Christmas", "test_dir")
-
+        christmas_imgs_per_child1 = corpus.get_filenames_child_images_for_event("Rilee", "Christmas")
+        christmas_imgs_per_child2 = corpus.get_filenames_child_images_for_event("child3", "Christmas")
+        christmas_imgs_per_unknown = corpus.get_filenames_child_images_for_event("asdfasdf", "Portraits")
+        print(christmas_imgs_per_unknown)
         assert len(christmas_imgs_per_child1) == 6
         assert len(christmas_imgs_per_child2) == 2
+        assert len(christmas_imgs_per_unknown) == 11
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/photocollage/render.py
+++ b/photocollage/render.py
@@ -272,8 +272,6 @@ class RenderingTask(Thread):
 
     def run(self):
         try:
-            print("rendering ", self.yearbook_page.event_name)
-            print("should render ", self.yearbook_page.final_image)
             canvas = PIL.Image.new(
                 "RGB", (int(self.page.w), int(self.page.h)), "white")
 


### PR DESCRIPTION
For now all rankers give back a list of images from the event directory
The ChildRanker provides images that are sorted by facial recognition score for the time being.